### PR TITLE
Configuration file: quoting of trello items

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ The full options are:
 * ``date-format``: The date format to use when creating dated lists. See strftime(1) for details of the formatting options (note that the script assumes use of numeric options only).  Defaults to ``%d/%m/%y``.
 
 Note that the script requires that `boardid`, `key` and `token are set
-either in the configuration file or on the command line. These values
-shoudl be the unquoted tokens from trello; if there are quotes present
-at the start and end of these three options they will be stripped. 
+either in the configuration file or on the command line.
+
+In the configuration file, these values should be the unquoted tokens
+from trello; if there are quotes present at the start and end of these
+three options they will be stripped. 
 
 As an example, a minimal main configuration is below; N.B. the values
 have been randomly generated, so are **NOT** valid for trello.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,19 @@ The full options are:
 * ``date-format``: The date format to use when creating dated lists. See strftime(1) for details of the formatting options (note that the script assumes use of numeric options only).  Defaults to ``%d/%m/%y``.
 
 Note that the script requires that `boardid`, `key` and `token are set
-either in the configuration file or on the command line.
+either in the configuration file or on the command line. These values
+shoudl be the unquoted tokens from trello; if there are quotes present
+at the start and end of these three options they will be stripped. 
+
+As an example, a minimal main configuration is below; N.B. the values
+have been randomly generated, so are **NOT** valid for trello.
+
+```
+[main]
+boardid=ua6oor0oL
+key=cf3e10a51fd05ef4a1944c7ccd713aa6
+token=6b8a8177589e02994c5183a881b6c91f6709f6dcc6711591c05eb3def190e04e
+```
 
 #### The `[rssfeeds]` section
 

--- a/munkistaging/config.py
+++ b/munkistaging/config.py
@@ -185,14 +185,23 @@ class MunkiStagingConfig(RawConfigParser):
  
        self.read_config_files = self.read(cfgfiles)
 
+    # Strips quotes form the begining and end of option values
+    # mainly to ensure that these are not present on the key, token
+    # and boardids
+    def _get_unquoted_option(self, section, key):
+        value = self._get_option(section, key)
+        value = re.sub('^(\'|")', '', value)
+        value = re.sub('(\'|")$', '', value)
+        return value
+
     def get_app_key(self):
-        return self._get_option('main', 'key')
+        return self._get_unquoted_option('main', 'key')
 
     def get_app_token(self):
-        return self._get_option('main', 'token')
+        return self._get_unquoted_option('main', 'token')
 
     def get_boardid(self):
-        return self._get_option('main', 'boardid')
+        return self._get_unquoted_option('main', 'boardid')
 
     def get_date_format(self):
         return self._get_option('main', 'date_format')


### PR DESCRIPTION
Add code to allow the trello board configuration (`key`, `token` and `boardid`)
to be quoted in the configuration file. As this is not the expected
situation, update the README file to try to encourage people to use
unquoted values. However, following the Robustness principle/Postel's
Law allow for this to happen.

Hopefully this improves the documentation and fixes issues encountered
in ox-it/munki-staging#21
