### PR TITLE
Detection of no repository in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ In order to get the maximum flexibility from the script, you will need
 to use a configuration file; however most options for the development,
 testing and production setup above are available on the command line.
 
+Note that if you use a configuration file you will need to specify
+a Munki repository section; this is because using the configuration file
+allows more than one repository to be used, overriding the default
+option from the command line.
+
 ### Example
 
 ```
@@ -107,9 +112,17 @@ munki-staging.cfg-template.
 The configuration file has several sections:
   * the `[main]` section with some global defaults
   * the optional `[rssfeeds]` section 
-  * Munki repository sections (`[munk_repo_<name>]`)
+  * Munki repository sections (`[munki_repo_<name>]`)
   * Munki catalog sections (`[munki_catalog_<name>]`)
-  * Auto stating schedule sections (`[schedule]` and/or `[schedule_<name>]`)
+  * Auto staging schedule sections (`[schedule]` and/or `[schedule_<name>]`)
+
+Note that if you use a configuration file you must provide at least
+the sections:
+  * main
+  * a Munki repository
+(any number of munki repositories can be used, but there must be at
+least one given as using the configuration file removes the default
+value for this setting)
 
 #### The `[main]` section
 

--- a/munki-staging.py
+++ b/munki-staging.py
@@ -42,14 +42,22 @@ config.read_config()
 packagelist = PackageList()
 
 makecatalogs = config.get_makecatalogs()
+repo_count = 0
 for mrepo_cfg in config.configured_munki_repositories():
     munki_repo = MunkiRepository(mrepo_cfg, makecatalogs)
     print "Finding packages in repository", munki_repo.name, "..."
+    repo_count = repo_count + 1
     for package in munki_repo.packages():
         packagelist.add_or_update_package(package)
 
     # Remember for future use
     config.add_munki_repo( munki_repo )
+
+if repo_count == 0:
+    print "No munki repositories configured"
+    print "  if you are using a configuration file you must specify at least"
+    print "  one munki_repo_<name> section"
+    sys.exit(1)
 
 print "Building Trello board data .... "
 munki_trello = MunkiTrelloBoard(config)

--- a/munkistaging/config.py
+++ b/munkistaging/config.py
@@ -113,7 +113,7 @@ class MunkiStagingConfig(RawConfigParser):
         repo_path = self._get_option('main', 'repo_path',
                           default_value=default_settings.repo_path)
 
-        return { 'repo_name': 'production', 'repo_path': repo_path }
+        return [  { 'repo_name': 'production', 'repo_path': repo_path } ]
 
     def add_munki_repo(self, repo):
         self.repositories[repo.name] = repo
@@ -183,7 +183,8 @@ class MunkiStagingConfig(RawConfigParser):
            self.read_config_files = self.read(configfiles)
            return
  
-       self.read_config_files = self.read(cfgfiles)
+       read_cfg_files = self.read(cfgfiles)
+       self.read_config_files = len(read_cfg_files)
 
     # Strips quotes form the begining and end of option values
     # mainly to ensure that these are not present on the key, token


### PR DESCRIPTION
If you use a configuration file, you need to specify a Munki
repository in the configuration file.

In this update we try to make this clearer in the documentation, as it
may have been hidden away before and add a check for this condition to
the main script to try to catch when this happens.

We also address two bugs that occur when no configuration are used.
Firstly, the detection of the fact there was no configuration file is
broken as  RawConfigParser.read returns an empty list and apparently
python thinks that '[] >= 1' is True; we now correctly use the length
of the list for this check. Secondly, the default value for the
repository with no configuration file was being returned as a
dictionary rather than a list, which we have now addressed.

These issues were discovered trying to assist with solve ox-it/munki-staging#21
