### PR TITLE
Add showconfig and some bugfixes

### DIFF
--- a/munki-staging.py
+++ b/munki-staging.py
@@ -42,14 +42,22 @@ config.read_config()
 packagelist = PackageList()
 
 makecatalogs = config.get_makecatalogs()
+repo_count = 0
 for mrepo_cfg in config.configured_munki_repositories():
     munki_repo = MunkiRepository(mrepo_cfg, makecatalogs)
     print "Finding packages in repository", munki_repo.name, "..."
+    repo_count = repo_count + 1
     for package in munki_repo.packages():
         packagelist.add_or_update_package(package)
 
     # Remember for future use
     config.add_munki_repo( munki_repo )
+
+if repo_count == 0:
+    print "No munki repositories configured"
+    print "  if you are using a configuration file you must specify at least"
+    print "  one munki_repo_<name> section"
+    sys.exit(1)
 
 print "Building Trello board data .... "
 munki_trello = MunkiTrelloBoard(config)
@@ -58,11 +66,13 @@ print "Building Munki repository data and packages .... "
 # Build the catalog lists
 # (to allow us to only consisder cards in the relevant lists)
 munki_trello.setup_catalog_lists()
-# XXX(aaron): calling this here is probably a bug, as it shouldn't need to
-#             be here other things should call this before they need it;
-#             this was on line 66, but again, I'm not sure if it needed to
-#             be there, as it should be called by the time it
-#             gets there.
+
+(check, reason) = munki_trello.check_list_setup()
+if check == False:
+    print 
+    print 'Error: Incorrect Trello setup detected: %s ' % reason
+    config.print_expected_trello()
+    sys.exit(1)
 
 print "Building Package list from Trello .... "
 for package in munki_trello.packages():
@@ -72,6 +82,12 @@ for package in munki_trello.packages():
        print "Deleting card without a package %s " % package.key()
        munki_trello.delete_package(package)
 
+
+if config.get_show_config():
+    munki_trello.print_catalog_lists()
+    print "\n Terminating run - no processing performed"
+    sys.exit(0)
+
 # At this point, we want to
 #   * find any packages missing a trello card a create the card
 #   * move packages in the 'To' trello lists into the correct catalog
@@ -80,7 +96,6 @@ for package in munki_trello.packages():
 #
 
 print "Finding missing packages .... "
-
 
 # Find packages not in the trello boards
 # N.B. Will add packages according to underlying munki catalog

--- a/munkistaging/default_settings.py
+++ b/munkistaging/default_settings.py
@@ -58,7 +58,7 @@ cli_options = [
 
     ( "--to-dev-list", "Name of the 'To Development' Trello list if none in the configuration file. Defaults to '%s'. " % DEFAULT_DEV_LIST, DEFAULT_DEV_LIST),
     ( "--dev-list", "Name of the 'Development' Trello list. Defaults to '%s'. " % DEFAULT_DEV_LIST, DEFAULT_DEV_LIST),
-    ("--dev-catalog", "Name of the Munki development catalog. Defaults to '%s'. " % DEFAULT_MUNKI_DEV_CATALOG, DEFAULT_DEV_LIST),
+    ("--dev-catalog", "Name of the Munki development catalog. Defaults to '%s'. " % DEFAULT_MUNKI_DEV_CATALOG, DEFAULT_MUNKI_DEV_CATALOG),
     ("--dev-stage-days", "The number of days that a package will remain in development before being prompoted to test (if staging is enabled).  Note: this does not enable staging", None),
 
 # Test Catalog/Trello

--- a/munkistaging/munki_trelloboard.py
+++ b/munkistaging/munki_trelloboard.py
@@ -89,7 +89,13 @@ class MunkiTrelloBoard:
             if self.list_id_catalog.has_key(listid):
                 trello_catalog = self.list_id_catalog[ card['idList'] ]
             else:
-                print "XXX card %s not in recognised list\n" % card['name']
+                try: 
+                    listname = self.trello_id_list[listid]['name']
+                except KeyError:
+                    listname = '(unknown)'
+
+                print "\tIgnoring card '%s' in unrecognised list '%s'" \
+                       % ( card['name'], listname )
                 continue
 
             try:
@@ -155,6 +161,7 @@ class MunkiTrelloBoard:
         if self.catalog_lists is None:
             self.setup_catalog_lists()
 
+        print self.catalog_lists.keys()
         return self.catalog_lists[catalog_list]
 
     def setup_catalog(self, config_dict, date_format):
@@ -277,6 +284,28 @@ class MunkiTrelloBoard:
         cardid = package.trello_card_id
         self.trello.cards.delete( cardid ) 
 
+    def print_catalog_lists(self):
+        if self.catalog_lists is None:
+            print '(Catalog lists not set up)'
+            return
+
+        for c in self.catalog_lists.keys():
+            print '\tUsing Catalog:  %s' % c
+            self.catalog_lists[c].print_catalog() 
+        return
+
+
+    def check_list_setup(self):
+        # Check that things are good to go: there must be at least
+        # one valid trello list, otherwise things will not really work
+
+        if self.catalog_lists is None:
+            return (False, 'Catalog lists not set up')
+
+        if len(self.catalog_lists) == 0:
+            return (False, 'Catalog lists not found')
+   
+        return (True, '')
 
 class MunkiTrelloBoardCatalogList:
     
@@ -391,3 +420,8 @@ class MunkiTrelloBoardCatalogList:
              return self.stage_from
 
          raise ValueError('Cannot find catalog %s to stage from' % self.stage_from_name)
+
+    def print_catalog(self):
+        print '\t\tTrello list %s' % self.list_name
+        print '\t\tTrello to list %s' % self.to_list_name
+        print '\t\tRelated Munki repository %s (path: %s) ' % (self.munki_repo_name, self.munki_repo.munki_path)

--- a/munkistaging/munki_trelloboard.py
+++ b/munkistaging/munki_trelloboard.py
@@ -161,7 +161,6 @@ class MunkiTrelloBoard:
         if self.catalog_lists is None:
             self.setup_catalog_lists()
 
-        print self.catalog_lists.keys()
         return self.catalog_lists[catalog_list]
 
     def setup_catalog(self, config_dict, date_format):


### PR DESCRIPTION
Add --showconfig option to display what the program thinks the trello
setup should be like

BugFix: if using config without defining trello lists, then this would
have not worked (and the documentation thinks it should)

BugFix: default settings: fix default option fo dev-catalog to be
DEFAULT_MUNKI_DEV_CATALOG and not the (incorrect) DEFAULT_DEV_LIST
