### PR TITLE
Try to track down bug with trello catalogs not having munki repositories

### DIFF
--- a/munkistaging/__init__.py
+++ b/munkistaging/__init__.py
@@ -219,6 +219,20 @@ class Package:
        # Set the due date (if autostaging is on)
        self.set_trello_due_date()
 
+       # Check to see if we need to move the package to a different
+       # repository
+       migrate_packages = 1
+       if self.munki_repo is None:
+           print "ERROR: package %s does not have a munki repository" % self
+           migrate_packages = 0
+
+       if self.trello_catalog.munki_repo is None:
+           print "ERROR: trello catalog %s does not have a munki repository" % self.trello_catalog.list_name
+           migrate_packages = 0
+
+       if migrate_packages == 0:
+           raise ValueError('Missing munki repository before migration check for package %s' % self) 
+
        if self.munki_repo.name != self.trello_catalog.munki_repo.name:
            self.migrate_package()
 

--- a/munkistaging/munki_trelloboard.py
+++ b/munkistaging/munki_trelloboard.py
@@ -184,6 +184,9 @@ class MunkiTrelloBoard:
             if self.config.repositories.has_key(munki_repo_name):
                munki_repo = self.config.repositories[munki_repo_name]
 
+         if munki_repo is None:
+             print "ERROR: Could not assign munki repo name %s to trello catalog %s (full list of repositories: %s) " % (munki_repo_name, list_name, self.config.repositories.keys())
+
          autostage_schedule = \
              self.config.autostage_schedule( config_dict['section_name'] )
   


### PR DESCRIPTION
As reported in ox-it/munki-staging#21 it seems there is a certian
configuration that will not assign a Munki repository to a package or
(more likely) a trello catalog. This commit adds code to try to track
down the source of this error which currently I am not able to
reproduce.
