### PR TITLE
Add a per-package override to staging days

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ $ python munki-staging.py --boardid 12345 --key myverylongkey --token myevenlong
 * ``--makecatalogs``: Optional. The path to ``makecatalogs``. Defaults to ``/usr/local/munki/makecatalogs``.
 * ``--date-format``: Optional. The date format to use when creating dated lists. See strftime(1) for details of the formating options.  Defaults to ``%d/%m/%y``.
 * ``--dev-stage-days``: Optional. Set the due date for autostaging; as packages are added into development, this will set the card due date to the current time plus the about of time given. You will need to seperately turn on staging, which is independent of this option.  Default: 0 (no due date set).
-* ``--stage-test``: Optional. Automatically promote packages with a due date set from the development list into the testing list. Note: there is a seperate option to enable the setting of the due date.  Default: False (no auto promotion to test).
-* ``--test-stage-dates``: Optional. Set the due date for autostaging; as packages are added into test, this will set the card due date to the current time plus the about of time given. You will need to seperately turn on staging, which is independent of this option.  Default: 0 (no due date set).
-* ``--stage-prod``: Optional. Automatically promote packages with a due date set from the testing list into the production list. Note: there is a seperate option to enable the setting of the due date.  Default: False (no auto promotion to test).
+* ``--stage-test``: Optional. Automatically promote packages with a due date set from the development list into the testing list. Note: there is a separate option to enable the setting of the due date.  Default: False (no auto promotion to test).
+* ``--test-stage-dates``: Optional. Set the due date for autostaging; as packages are added into test, this will set the card due date to the current time plus the about of time given. You will need to separately turn on staging, which is independent of this option.  Default: 0 (no due date set).
+* ``--stage-prod``: Optional. Automatically promote packages with a due date set from the testing list into the production list. Note: there is a separate option to enable the setting of the due date.  Default: False (no auto promotion to test).
 
 ## Configuration file
 
@@ -370,7 +370,7 @@ may be some packages that you wish to stage faster than the default
 For this reason, there is a feature to allow you to change the staging
 days on a per-package basis. To do this you will need to edit the
 ``pkgsinfo`` file for the package, adding a munki_staging key which
-has a dictoinary value. Within this dictionary you can set a
+has a dictionary value. Within this dictionary you can set a
 stage_days parameter which overrides the default number of days.
 
 For example, to stage a package with 1 days worth of testing you would
@@ -401,16 +401,11 @@ where
 * ``--stagedays``:  optional; the number of days to stage 
 * ``<pkgsinfo_file>``: is a path to a pkgsinfo file
 
-If run without an argment will report on the number of staging days
+If run without an argument will report on the number of staging days
 that are configured within each of the pkgsinfo files listed.
 
 *NB* The munki staging configuration file is *not* read by this helper
 file.
-
-
-### Command line Options
-
-* ``--boardid``: Required. The ID of your Trello board.
 
 # Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ description_template='Software packages in Orchard %(catalog)s catalog'
 icon_url_template=https://site.orchard.ox.ac.uk/munki/%(icon_path)s
 ```
 
-
 #### The Munki catalog sections `[munki_catalog_<name>]`
 
 The Munki catalog sections contain information about different Munki
@@ -215,6 +214,10 @@ The full options are:
 * ``autostage``: Default: 0 (off). Whether or not to automatically promote packages based on the Trello card due date.
 * ``munki_repo``: The name of the underlying Munki repository (if using more than one Munki repository.
 * ``dated_lists``: Default: 0 (off). If new Trello lists are created when packages are moved into this catalog, based on the date the packages are moved.
+
+Note that the ``stage_days`` parameter can be overridden in individual
+``pkgsinfo`` files on a per-package basis; see the section on
+autostaging for more details.
 
 #### The Munki repository sections `[munki_catalog_<name>]`
 
@@ -355,6 +358,59 @@ Thus if you have 3 catalogs:
 then in order to stage packages into production you need to turn on
 auto staging for testing. In order to stage packages into testing, you
 need to turn on autostaging for development.
+
+### Staging Speed
+
+If you use autostaging, you will need to set the number of days in
+which a package get staged. This is set on the Munki catalog using the
+``stage_days`` setting for all packages in a catalog. However, there
+may be some packages that you wish to stage faster than the default
+(e.g. a security release).
+
+For this reason, there is a feature to allow you to change the staging
+days on a per-package basis. To do this you will need to edit the
+``pkgsinfo`` file for the package, adding a munki_staging key which
+has a dictoinary value. Within this dictionary you can set a
+stage_days parameter which overrides the default number of days.
+
+For example, to stage a package with 1 days worth of testing you would
+add the following to the pkginfo file:
+```
+       <key>munki_staging</key>
+       <dict>
+               <key>stage_days</key>
+               <string>1</string>
+       </dict>
+
+```
+This would then override the setting for the catalog, if autostaging
+is enabled.
+
+In order to help with this, there is a python script that you can use
+to set the number of staging days for a package; this script
+``munkistaging-pkgsinfo.py`` can be run as below to set the staging
+days to be 1 (as in the above pkgsinfo file):
+```
+$ python munkistaging-pkgsinfo.py --stagedays 1 /path/to/pkgsinfo/file
+```
+The full usage is:
+```
+$ munkistaging-pkgsinfo.py [--stagedays <n>] <pkgsinfo_file>+
+```
+where 
+* ``--stagedays``:  optional; the number of days to stage 
+* ``<pkgsinfo_file>``: is a path to a pkgsinfo file
+
+If run without an argment will report on the number of staging days
+that are configured within each of the pkgsinfo files listed.
+
+*NB* The munki staging configuration file is *not* read by this helper
+file.
+
+
+### Command line Options
+
+* ``--boardid``: Required. The ID of your Trello board.
 
 # Troubleshooting
 

--- a/bin/munkistaging-pkgsinfo.py
+++ b/bin/munkistaging-pkgsinfo.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+#
+# This software is Copyright (c) 2015 University of Oxford
+#
+# This work is made avaiable to you under the terms of the Apache
+# License, Version 2.0; you may not use this source code except in
+# compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+import plistlib
+import argparse
+import os
+import sys
+
+options = argparse.ArgumentParser(description='Configure the optional munki_staging section in a pkgsinfo file')
+
+options.add_argument('--stagedays', help='number of days to stage a package by', default=None, type=int)
+
+options.add_argument('pkgsinfo', help='pkgsinfo files to operate on',
+ nargs='+')
+
+args = options.parse_args()
+
+stagedays = -1
+if args.__contains__('stagedays') and args.stagedays is not None:
+    stagedays = args.stagedays
+    if stagedays < 0:
+        print "Can only set stagedays to be a positive integer"
+        sys.exit(1)
+
+for file in args.pkgsinfo:
+    if not os.path.exists(file):
+        print "Skippking pkgsinfo file: %s (not found)" % file
+        continue
+
+    pkgsinfo = plistlib.readPlist(file)
+
+    munkistaging = {}
+    if pkgsinfo.has_key('munki_staging'):
+        munkistaging = pkgsinfo['munki_staging']
+
+    days = '(unset)'
+    if munkistaging.has_key('stage_days'):
+        days = munkistaging['stage_days']
+
+    if stagedays >=0:
+        munkistaging['stage_days'] = stagedays
+        pkgsinfo['munki_staging'] = munkistaging
+        plistlib.writePlist(pkgsinfo,file)
+        print 'Changing %s staging days from %s to %d' % (file, days, stagedays)
+        continue
+
+    print '%s has staging days %s' % (file, days)
+


### PR DESCRIPTION
Currently the number of days to autostage a package is set in the
configuration file for munki-staging on a per-trello list/munki
catalog basis.

This patch adds the option to also set a per-package number of staging
days by creating a 'munki_staging' key in a pkgsinfo file. It also
adds a python script that will do this. This will override the default
setting.

Note: autostaging must be on for this to have any effect
