### PR TITLE
Ignore invisible files (starting with '.') when looping over pkgsinfo

### DIFF
--- a/munkistaging/munki_repo.py
+++ b/munkistaging/munki_repo.py
@@ -49,22 +49,24 @@ class MunkiRepository:
         self.package_list = []
         for root, dirs, files in os.walk( self.pkgsinfo_path ) :
             for file in files:
-                # It is conceivable there are broken / non plist files
-                # so we try to parse the files, just in case
-                pkgsinfo = os.path.join(root, file)
-                try: 
-                    plist = plistlib.readPlist(pkgsinfo)
-                except Exception as e:
-                   print 'Ignoring invalid pkgsinfo file %s' % (pkgsinfo)
-                   print '(Error: %s)' % (e)
-                   continue
-  
-                package = Package( plist['name'], plist['version'],
-                                   pkgsinfo=pkgsinfo,
-                                   munki_catalogs=plist['catalogs'],
-                                   munki_repo=self)
+                # Ingore invisible files
+                if not file.startswith('.'):
+                  # It is conceivable there are broken / non plist files
+                  # so we try to parse the files, just in case
+                  pkgsinfo = os.path.join(root, file)
+                  try: 
+                      plist = plistlib.readPlist(pkgsinfo)
+                  except Exception as e:
+                     print 'Ignoring invalid pkgsinfo file %s' % (pkgsinfo)
+                     print '(Error: %s)' % (e)
+                     continue
+    
+                  package = Package( plist['name'], plist['version'],
+                                     pkgsinfo=pkgsinfo,
+                                     munki_catalogs=plist['catalogs'],
+                                     munki_repo=self)
 
-                self.package_list.append(package)
+                  self.package_list.append(package)
                 
         return self.package_list
 

--- a/munkistaging/munki_repo.py
+++ b/munkistaging/munki_repo.py
@@ -50,23 +50,25 @@ class MunkiRepository:
         for root, dirs, files in os.walk( self.pkgsinfo_path ) :
             for file in files:
                 # Ingore invisible files
-                if not file.startswith('.'):
-                  # It is conceivable there are broken / non plist files
-                  # so we try to parse the files, just in case
-                  pkgsinfo = os.path.join(root, file)
-                  try: 
-                      plist = plistlib.readPlist(pkgsinfo)
-                  except Exception as e:
-                     print 'Ignoring invalid pkgsinfo file %s' % (pkgsinfo)
-                     print '(Error: %s)' % (e)
-                     continue
-    
-                  package = Package( plist['name'], plist['version'],
+                if file.startswith('.'):
+                  print 'Ignoring hidden file %s' % (file)
+                  continue
+                # It is conceivable there are broken / non plist files
+                # so we try to parse the files, just in case
+                pkgsinfo = os.path.join(root, file)
+                try: 
+                    plist = plistlib.readPlist(pkgsinfo)
+                except Exception as e:
+                   print 'Ignoring invalid pkgsinfo file %s' % (pkgsinfo)
+                   print '(Error: %s)' % (e)
+                   continue
+
+                package = Package( plist['name'], plist['version'],
                                      pkgsinfo=pkgsinfo,
                                      munki_catalogs=plist['catalogs'],
                                      munki_repo=self)
 
-                  self.package_list.append(package)
+                self.package_list.append(package)
                 
         return self.package_list
 


### PR DESCRIPTION
munki-staging will print a warning every time it encounters an invisible file. Like so:

```
Ignoring invalid pkgsinfo file /usr/local/munki_repo/pkgsinfo/utility/Oracle/.DS_Store
(Error: not well-formed (invalid token): line 1, column 0)
```

These files can be ignored by implementing a simple check.
